### PR TITLE
Don't require module argument

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ type Configs struct {
 	ProjectLocation string `env:"project_location,dir"`
 	APKPathPattern  string `env:"apk_path_pattern"`
 	Variant         string `env:"variant,required"`
-	Module          string `env:"module,required"`
+	Module          string `env:"module"`
 	Arguments       string `env:"arguments"`
 	CacheLevel      string `env:"cache_level,opt[none,only_deps,all]"`
 	DeployDir       string `env:"BITRISE_DEPLOY_DIR,dir"`

--- a/step.yml
+++ b/step.yml
@@ -35,7 +35,6 @@ inputs:
         Set the module that you want to build. To see your available modules please open your project in Android Studio and go in [Project Structure] and see the list on the left.
       description: |
         Set the module that you want to build. To see your available modules please open your project in Android Studio and go in [Project Structure] and see the list on the left.
-      is_required: true
   - variant: ""
     opts:
       title: Variant


### PR DESCRIPTION
Align with steps like [bitrise-step-android-unit-test](https://github.com/bitrise-steplib/bitrise-step-android-unit-test).

Allows to use this step for projects where `src` is in root path (not in a module).