### PR TITLE
Test running on JDK 11

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -3,58 +3,74 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 app:
   envs:
-    # Shared test configs
-    - TEST_APP_URL: https://github.com/bitrise-io/android-multiple-test-results-sample.git
-    - TEST_APP_BRANCH: maintenance
+  # Shared test configs
+  - TEST_APP_URL: https://github.com/bitrise-io/android-multiple-test-results-sample.git
+  - TEST_APP_BRANCH: maintenance
 
 workflows:
   test_app:
     envs:
-      - TEST_APP_MODULE: app
-      - TEST_APP_VARIANT: DemoDebug
+    - TEST_APP_MODULE: app
+    - TEST_APP_VARIANT: DemoDebug
     after_run:
-      - _run
-      - _check_outputs
+    - _run
+    - _check_outputs
 
   test_another_app:
     envs:
-      - TEST_APP_MODULE: another_app
-      - TEST_APP_VARIANT: AnotherDemoDebug
+    - TEST_APP_MODULE: another_app
+    - TEST_APP_VARIANT: AnotherDemoDebug
     after_run:
-      - _run
-      - _check_outputs
+    - _run
+    - _check_outputs
 
   _run:
     steps:
-      - script:
-          inputs:
-            - content: |-
-                #!/bin/env bash
-                set -ex
-                rm -rf ./_tmp
-      - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git@master:
-          inputs:
-            - repository_url: $TEST_APP_URL
-            - branch: $TEST_APP_BRANCH
-            - clone_into_dir: ./_tmp
-      - install-missing-android-tools:
-          run_if: .IsCI
-          inputs:
-            - gradlew_path: ./_tmp/gradlew
-      - path::./:
-          inputs:
-            - project_location: ./_tmp
-            - module: $TEST_APP_MODULE
-            - variant: $TEST_APP_VARIANT
+    - script:
+        run_if: $.IsCI
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -ex
+            if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+              sudo update-alternatives --set javac /usr/lib/jvm/java-11-openjdk-amd64/bin/javac
+              sudo update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
+              export JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
+              envman add --key JAVA_HOME --value "/usr/lib/jvm/java-11-openjdk-amd64"
+            elif [[ "$OSTYPE" == "darwin"* ]]; then
+              jenv global 11
+              export JAVA_HOME="$(jenv prefix)"
+              envman add --key JAVA_HOME --value "$(jenv prefix)"
+            fi
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -ex
+            rm -rf ./_tmp
+    - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git@master:
+        inputs:
+        - repository_url: $TEST_APP_URL
+        - branch: $TEST_APP_BRANCH
+        - clone_into_dir: ./_tmp
+    - install-missing-android-tools:
+        run_if: .IsCI
+        inputs:
+        - gradlew_path: ./_tmp/gradlew
+    - path::./:
+        inputs:
+        - project_location: ./_tmp
+        - module: $TEST_APP_MODULE
+        - variant: $TEST_APP_VARIANT
 
   _check_outputs:
     steps:
-      - script:
-          title: Check outputs
-          inputs:
-            - content: |-
-                #!/usr/bin/env bash
-                set -ex
+    - script:
+        title: Check outputs
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -ex
 
-                if [ -z "$BITRISE_APK_PATH" ] ; then echo "BITRISE_APK_PATH env is empty" ; exit 1 ; fi ;
-                if [ -z "$BITRISE_TEST_APK_PATH" ] ; then echo "BITRISE_TEST_APK_PATH env is empty" ; exit 1 ; fi ;
+            if [ -z "$BITRISE_APK_PATH" ] ; then echo "BITRISE_APK_PATH env is empty" ; exit 1 ; fi ;
+            if [ -z "$BITRISE_TEST_APK_PATH" ] ; then echo "BITRISE_TEST_APK_PATH env is empty" ; exit 1 ; fi ;


### PR DESCRIPTION
### Checklist

- [ ] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _MAJOR / MINOR / PATCH_ [version update](https://semver.org/)

### Context

<!--- One sentence summary on why the change is needed. -->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.
-->

### Changes

- Reindent bitrise.yml
- Enable JDK 11 at runtime

Not visible in this PR, but the E2E sample apps were updated to run on JDK11. These apps now require JDK 11, so let's merge this PR until the new default JDK is set on the stacks.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
